### PR TITLE
Fixed missing bracket and typo in readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -117,7 +117,7 @@ You can also run this to set the installation path:
 ----
 curl -Ls -o vista-fonts-installer.sh https://raw.githubusercontent.com/metanorma/vista-fonts-installer/master/vista-fonts-installer.sh
 chmod +x vista-fonts-installer.sh
-./vistra-fonts-installer.sh --accept-microsoft-eula [desired-path]
+./vista-fonts-installer.sh --accept-microsoft-eula [desired-path]
 ----
 
 `--accept-microsoft-eula`:: will automatically accept the EULA if this flag is passed.

--- a/vista-fonts-installer.sh
+++ b/vista-fonts-installer.sh
@@ -367,7 +367,7 @@ main() {
   rm -rf "$temp_dir" || \
     errx "Unable to remove temp directory ${temp_dir}."
 
-  if [ "${platform}" == "ubuntu" ] && [ ! $(which fc-cache) ; then
+  if [ "${platform}" == "ubuntu" ] && [ ! $(which fc-cache) ]; then
     echo ":: Cleaning the font cache... " >&2
     fc-cache -f "$MS_FONT_PATH" || \
       errx "Unable to clean font cache via 'fc-cache'. Exiting."


### PR DESCRIPTION
- Fixed missing bracket in vista-fonts-installer.sh
- Fixed a typo in the readme.

Fixes #7 
Fixes #8 